### PR TITLE
Changed default aws credentials conn to 'aws_default'

### DIFF
--- a/airflow/hooks/S3_hook.py
+++ b/airflow/hooks/S3_hook.py
@@ -97,7 +97,7 @@ class S3Hook(BaseHook):
 
     def __init__(
             self,
-            s3_conn_id='s3_default'):
+            s3_conn_id='aws_default'):
         self.s3_conn_id = s3_conn_id
         self.s3_conn = self.get_connection(s3_conn_id)
         self.extra_params = self.s3_conn.extra_dejson

--- a/airflow/hooks/aws_emr.py
+++ b/airflow/hooks/aws_emr.py
@@ -12,7 +12,7 @@ from subprocess import Popen, STDOUT, PIPE
 class EMRHook(BaseHook):
     STATES = ['TERMINATED', 'TERMINATED_WITH_ERRORS', 'RUNNING', 'WAITING']
 
-    def __init__(self, emr_conn_id="s3_default", region="us-west-2"):
+    def __init__(self, emr_conn_id="aws_default", region="us-west-2"):
         self.region_name = region
         self.emr_conn_id = emr_conn_id
         self.emr_conn = self.get_connection(emr_conn_id)

--- a/airflow/hooks/sqs_hook.py
+++ b/airflow/hooks/sqs_hook.py
@@ -8,7 +8,7 @@ import boto3
 class SQSHook(BaseHook):
 
     def __init__(self, queue_name=None,
-                 sqs_conn_id="s3_default",
+                 sqs_conn_id="aws_default",
                  region="us-west-2"):
         self.region_name = region
         self.sqs_conn_id = sqs_conn_id

--- a/airflow/operators/S3_to_FS.py
+++ b/airflow/operators/S3_to_FS.py
@@ -27,7 +27,7 @@ class S3ToFileSystem(BaseOperator):
             s3_bucket,
             s3_key,
             download_file_location,
-            s3_conn_id='s3_default',
+            s3_conn_id='aws_default',
             * args, **kwargs):
 
         super(S3ToFileSystem, self).__init__(*args, **kwargs)

--- a/airflow/operators/aws_emr_operator.py
+++ b/airflow/operators/aws_emr_operator.py
@@ -105,7 +105,7 @@ class AwsEMROperator(BaseOperator):
             local_path = os.path.join(self.dn_dir, basename)
             s3_hook.download_file(bucket, key, local_path)
 
-        job_monitor = EMRHook(emr_conn_id="S3_default")
+        job_monitor = EMRHook(emr_conn_id="aws_default")
         if self.start_cluster:
             output_id = self.exec_command(self.construct_command())
             context['ti'].xcom_push(key="code", value=output_id)

--- a/airflow/operators/redshift_to_s3_operator.py
+++ b/airflow/operators/redshift_to_s3_operator.py
@@ -52,7 +52,7 @@ class RedshiftToS3Transfer(BaseOperator):
             s3_bucket,
             s3_key,
             redshift_conn_id='redshift_default',
-            s3_conn_id='s3_default',
+            s3_conn_id='aws_default',
             unload_options=tuple(),
             autocommit=False,
             parameters=None,

--- a/airflow/operators/s3_file_transform_operator.py
+++ b/airflow/operators/s3_file_transform_operator.py
@@ -60,8 +60,8 @@ class S3FileTransformOperator(BaseOperator):
             source_s3_key,
             dest_s3_key,
             transform_script,
-            source_s3_conn_id='s3_default',
-            dest_s3_conn_id='s3_default',
+            source_s3_conn_id='aws_default',
+            dest_s3_conn_id='aws_default',
             replace=False,
             *args, **kwargs):
         super(S3FileTransformOperator, self).__init__(*args, **kwargs)

--- a/airflow/operators/s3_to_hive_operator.py
+++ b/airflow/operators/s3_to_hive_operator.py
@@ -97,7 +97,7 @@ class S3ToHiveTransfer(BaseOperator):
             headers=False,
             check_headers=False,
             wildcard_match=False,
-            s3_conn_id='s3_default',
+            s3_conn_id='aws_default',
             hive_cli_conn_id='hive_cli_default',
             input_compressed=False,
             *args, **kwargs):

--- a/airflow/operators/s3_to_redshift_operator.py
+++ b/airflow/operators/s3_to_redshift_operator.py
@@ -50,7 +50,7 @@ class CopyS3ToRedshift(BaseOperator):
             s3_path = None,
             s3_path_xcom_ti = None,
             redshift_conn_id='redshift_default',
-            s3_conn_id='s3_default',
+            s3_conn_id='aws_default',
             region='us-west-2',
             file_format = 'CSV',
             quotechar = '"',

--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -502,7 +502,7 @@ class S3KeySensor(BaseSensorOperator):
             self, bucket_key,
             bucket_name=None,
             wildcard_match=False,
-            s3_conn_id='s3_default',
+            s3_conn_id='aws_default',
             *args, **kwargs):
         super(S3KeySensor, self).__init__(*args, **kwargs)
         # Parse
@@ -556,7 +556,7 @@ class S3PrefixSensor(BaseSensorOperator):
     def __init__(
             self, bucket_name,
             prefix, delimiter='/',
-            s3_conn_id='s3_default',
+            s3_conn_id='aws_default',
             *args, **kwargs):
         super(S3PrefixSensor, self).__init__(*args, **kwargs)
         # Parse


### PR DESCRIPTION
We had a bunch of different identical aws default connections. This was
silly. I chose 'aws_default' because not every operator or service needs
S3. I don't mind changing it to 's3_default', which I believe was the
default conn that airflow used in the apache repo, either.

It's stupid, I know, but it was actually pretty annoying to change credentials in testing.